### PR TITLE
fix: DISTRO validation breaks macOS deployment

### DIFF
--- a/deploy/dependencies.sh
+++ b/deploy/dependencies.sh
@@ -9,7 +9,11 @@
 
 # Validate required variables
 : "${OS:?Error: OS must be set}"
-: "${DISTRO:?Error: DISTRO must be set (can be empty for macOS)}"
+# DISTRO can be empty for macOS, so just check if variable exists
+if [ -z "${DISTRO+x}" ]; then
+    echo "Error: DISTRO variable must be set (can be empty string for macOS)"
+    exit 1
+fi
 
 print_header "Step 1: System Dependencies"
 


### PR DESCRIPTION
## Summary

Fixes macOS deployment script failure caused by DISTRO variable validation requiring non-empty value.

## Problem

The deploy script was failing on macOS with this error:
```
DISTRO: Error: DISTRO must be set (can be empty for macOS)
```

Despite `config.sh` correctly setting `DISTRO=""` for macOS, the validation in `dependencies.sh` used bash parameter expansion `: "${DISTRO:?...}"` which requires the variable to be both set AND non-empty.

## Solution

Changed the validation to use `[ -z "${DISTRO+x}" ]` which checks if the variable exists but allows empty values. This matches the actual requirement: DISTRO must be set (for the variable to exist), but can be empty for macOS.

## Testing

Tested on macOS - deployment script now proceeds past the DISTRO validation step successfully.

## Changes

- `deploy/dependencies.sh`: Updated DISTRO validation logic (lines 12-16)