### PR TITLE
fix: enforce Python 3.12+ requirement on macOS

### DIFF
--- a/deploy/dependencies.sh
+++ b/deploy/dependencies.sh
@@ -165,7 +165,19 @@ elif [ "$OS" = "macos" ]; then
     echo -e "${CHECKMARK}"
 
     # Detect Python version to use (newest available, 3.12+ required)
-    PYTHON_VER=$(python3 --version 2>&1 | sed -n 's/Python \([0-9]*\.[0-9]*\).*/\1/p')
+    # Check for Python 3.12+ in descending order of preference
+    PYTHON_VER=""
+    for ver in 3.14 3.13 3.12; do
+        if command -v python${ver} &> /dev/null; then
+            PYTHON_VER="${ver}"
+            break
+        fi
+    done
+    
+    # If no suitable version found, default to 3.12 for installation
+    if [ -z "$PYTHON_VER" ]; then
+        PYTHON_VER="3.12"
+    fi
 
     if [ "$LOUD_MODE" = true ]; then
         print_step "Updating Homebrew..."

--- a/deploy/python.sh
+++ b/deploy/python.sh
@@ -23,9 +23,7 @@ if [ "$OS" = "linux" ]; then
     fi
     PYTHON_CMD="python${PYTHON_VER}"
 elif [ "$OS" = "macos" ]; then
-    # Detect macOS Python version
-    PYTHON_VER=$(python3 --version 2>&1 | sed -n 's/Python \([0-9]*\.[0-9]*\).*/\1/p')
-
+    # PYTHON_VER already set by dependencies.sh to 3.12+ version
     # Check common Homebrew locations
     if command -v python${PYTHON_VER} &> /dev/null; then
         PYTHON_CMD="python${PYTHON_VER}"
@@ -42,6 +40,15 @@ fi
 
 PYTHON_VERSION=$($PYTHON_CMD --version 2>&1 | awk '{print $2}')
 echo -e "${CHECKMARK} ${DIM}$PYTHON_VERSION${RESET}"
+
+# Validate Python version is 3.12 or higher
+PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+if [ "$PYTHON_MAJOR" -lt 3 ] || { [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -lt 12 ]; }; then
+    print_error "MIRA requires Python 3.12 or higher. Found: $PYTHON_VERSION"
+    print_info "Please install Python 3.12+ and re-run the deployment script."
+    exit 1
+fi
 
 print_header "Step 3: MIRA Download & Installation"
 


### PR DESCRIPTION
## Summary

Fixes deployment script to enforce Python 3.12+ requirement on macOS, preventing ImportError when using older Python versions.

## Problem

The deployment script was using whatever `python3` symlink pointed to (often Python 3.10 on systems with multiple versions), causing this error:
```
ImportError: cannot import name 'UTC' from 'datetime'
```

`datetime.UTC` was added in Python 3.11, and MIRA requires Python 3.12+, but the script didn't enforce this requirement.

## Root Cause

On macOS with Homebrew, multiple Python versions can be installed but the `python3` symlink typically points to the oldest version. The script was detecting the system default Python instead of checking for already-installed 3.12+ versions.

## Solution

1. **dependencies.sh**: Check for Python 3.12+ in descending preference order (3.14 → 3.13 → 3.12) before falling back to requesting 3.12 installation
2. **python.sh**: Remove redundant version detection (now uses value from dependencies.sh)
3. **python.sh**: Add explicit version validation to fail fast with clear error if Python < 3.12 is somehow used

## Testing

Tested the Python version detection logic on macOS with multiple Python versions installed:
- Correctly detects Python 3.14 when available
- Version validation passes for 3.12+
- Would fail with clear error message for versions < 3.12

## Changes

- `deploy/dependencies.sh`: Lines 172-183 - Loop through Python versions 3.14/3.13/3.12
- `deploy/python.sh`: Lines 26-28 - Remove redundant detection
- `deploy/python.sh`: Lines 44-51 - Add version validation