### PR TITLE
fix: Docker container startup failures + docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# MIRA Environment Configuration
+# Copy this file to .env and fill in your API keys.
+#
+# If these are set, first-boot runs non-interactively.
+# If omitted, run with: docker compose run -it mira
+# to get the interactive setup wizard.
+
+# Required: Anthropic API key (get one at console.anthropic.com/settings/keys)
+MIRA_ANTHROPIC_KEY=sk-ant-your-key-here
+
+# Required: Generic provider API key for fast inference (e.g. Groq, OpenRouter)
+MIRA_PROVIDER_KEY=gsk_your-key-here
+
+# Optional: Provider configuration (defaults to Groq)
+# MIRA_PROVIDER_NAME=Groq
+# MIRA_PROVIDER_ENDPOINT=https://api.groq.com/openai/v1/chat/completions
+# MIRA_PROVIDER_MODEL=
+
+# Optional: Separate Anthropic key for batch operations (defaults to main key)
+# MIRA_ANTHROPIC_BATCH_KEY=
+
+# Optional: Kagi search API key (kagi.com/settings?p=api)
+# MIRA_KAGI_KEY=
+
+# Optional: Custom database password (defaults to internal default)
+# MIRA_DB_PASSWORD=

--- a/clients/llm_provider.py
+++ b/clients/llm_provider.py
@@ -2130,7 +2130,6 @@ class LLMProvider:
                 api_key_override=api_key_override,
                 system_override=system_override,
                 allow_negative=allow_negative,
-                cancel_event=cancel_event,
             ):
                 if isinstance(event, CompleteEvent):
                     response = event.response

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -30,7 +30,12 @@ COPY deploy/docker/scripts/container-setup.sh /opt/mira/container-setup.sh
 COPY deploy/docker/scripts/healthcheck.sh /opt/mira/healthcheck.sh
 COPY deploy/docker/scripts/vault-unseal.sh /opt/mira/app/deploy/docker/scripts/vault-unseal.sh
 RUN chmod +x /init-mira.sh /opt/mira/container-setup.sh /opt/mira/healthcheck.sh \
-    /opt/mira/app/deploy/docker/scripts/vault-unseal.sh
+    /opt/mira/app/deploy/docker/scripts/vault-unseal.sh \
+    && chmod +x /etc/s6-overlay/s6-rc.d/mira/run \
+                /etc/s6-overlay/s6-rc.d/vault/run \
+                /etc/s6-overlay/s6-rc.d/valkey/run \
+                /etc/s6-overlay/s6-rc.d/postgresql/run \
+                /etc/s6-overlay/s6-rc.d/vault-init/up
 
 # Expose ports
 EXPOSE 1993

--- a/deploy/docker/s6-rc.d/mira/run
+++ b/deploy/docker/s6-rc.d/mira/run
@@ -10,7 +10,7 @@ export VAULT_ADDR="http://127.0.0.1:8200"
 echo "Waiting for Vault to be unsealed..."
 attempts=0
 while true; do
-    SEALED=$(curl -s http://127.0.0.1:8200/v1/sys/health | jq -r '.sealed // "error"')
+    SEALED=$(curl -sf http://127.0.0.1:8200/v1/sys/health | jq -r '.sealed' 2>/dev/null || echo "error")
     if [ "$SEALED" = "false" ]; then
         echo "Vault is unsealed"
         break
@@ -33,5 +33,8 @@ export VAULT_ROLE_ID=$(cat /opt/vault/role-id.txt)
 export VAULT_SECRET_ID=$(cat /opt/vault/secret-id.txt)
 
 # Change to app directory and run as mira user
+# Set HOME and HF_HOME so sentence-transformers finds the cached model
+export HOME=/home/mira
+export HF_HOME=/home/mira/.cache/huggingface
 cd /opt/mira/app
 exec s6-setuidgid mira /opt/mira/venv/bin/python3 main.py

--- a/deploy/docker/s6-rc.d/vault-init/up
+++ b/deploy/docker/s6-rc.d/vault-init/up
@@ -1,19 +1,15 @@
-#!/bin/bash
-# Vault unseal oneshot for s6-overlay
-# Runs after vault service starts, unseals vault and sets up AppRole auth
-
-echo "Waiting for Vault to be ready..."
-
-# Wait for Vault to be listening (up to 30 seconds)
+/bin/bash -c "
+export VAULT_ADDR=http://127.0.0.1:8200
+echo 'Waiting for Vault to be ready...'
 attempts=0
 while ! curl -s http://127.0.0.1:8200/v1/sys/health > /dev/null 2>&1; do
     attempts=$((attempts + 1))
     if [ $attempts -gt 30 ]; then
-        echo "ERROR: Vault not responding after 30 seconds"
+        echo 'ERROR: Vault not responding after 30 seconds'
         exit 1
     fi
     sleep 1
 done
-
-echo "Vault is listening, running unseal script..."
+echo 'Vault is listening, running unseal script...'
 exec /opt/mira/app/deploy/docker/scripts/vault-unseal.sh
+"

--- a/deploy/docker/scripts/init-mira.sh
+++ b/deploy/docker/scripts/init-mira.sh
@@ -8,8 +8,9 @@
 
 set -e
 
-# Source output helpers for consistent formatting
+# Source helper libraries for consistent formatting and utility functions
 source /opt/mira/app/deploy/lib/output.sh
+source /opt/mira/app/deploy/lib/services.sh
 LOUD_MODE=false
 
 # =============================================================================

--- a/deploy/docker/scripts/vault-unseal.sh
+++ b/deploy/docker/scripts/vault-unseal.sh
@@ -2,8 +2,6 @@
 # Vault unseal script for s6-overlay container restarts
 # Simplified version without fancy output functions
 
-set -e
-
 export VAULT_ADDR="http://127.0.0.1:8200"
 
 echo "vault-unseal: Checking Vault status..."
@@ -16,6 +14,7 @@ fi
 
 # Check seal status using vault status exit codes
 # 0 = unsealed, 2 = sealed, 1 = error
+# Note: do NOT use set -e because vault status returns 2 when sealed (expected)
 vault status > /dev/null 2>&1
 STATUS=$?
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+# MIRA - Docker Compose
+# All services (PostgreSQL, Valkey, Vault, MIRA) run inside a single container
+# managed by s6-overlay process supervisor.
+#
+# Quick start:
+#   1. Copy .env.example to .env and fill in your API keys
+#   2. docker compose up --build
+#
+# First run will be slow (building base image with ML models ~15-20 min).
+# Subsequent rebuilds after code changes take seconds.
+
+services:
+  mira:
+    build:
+      context: .
+      dockerfile: deploy/docker/Dockerfile
+      args:
+        BASE_IMAGE: mira-base:latest
+    image: mira:latest
+    container_name: mira
+    ports:
+      - "1993:1993"
+    env_file:
+      - .env
+    volumes:
+      - mira-vault:/opt/vault
+      - mira-postgres:/var/lib/postgresql/17/main
+      - mira-valkey:/var/lib/valkey
+      - mira-models:/home/mira/.cache/huggingface
+    restart: unless-stopped
+
+volumes:
+  mira-vault:
+  mira-postgres:
+  mira-valkey:
+  mira-models:


### PR DESCRIPTION
## Summary
- Fix 6 bugs that prevented the Docker container from starting: missing shell source, `set -e` killing vault unseal, execlineb/bash interpreter mismatch, missing +x on s6 scripts, broken jq fallback + missing HF_HOME, and undefined `cancel_event` in llm_provider
- Add `docker-compose.yml` and `.env.example` for easy local development

## Details

**Docker infrastructure (5 bugs):**
- `init-mira.sh` didn't source `services.sh`, so `check_exists` was undefined during Vault init
- `vault-unseal.sh` used `set -e` which killed the script when `vault status` returned exit code 2 (sealed) — the expected pre-unseal state
- `vault-init/up` had a bash shebang but s6-rc oneshot `up` files are run by execlineb — rewrote to call `/bin/bash -c` explicitly
- `Dockerfile` didn't `chmod +x` the s6 service scripts, so shebangs were ignored
- `mira/run` had a broken jq `// "error"` expression and was missing `HOME`/`HF_HOME` for the mira user (sentence-transformers looked in `/root/.cache`)

**Application bug (1 bug):**
- `llm_provider.py:2133` referenced undefined `cancel_event` variable — removed since `_stream_response` doesn't accept it and `check_cancelled()` already handles cancellation

## Test plan
- [x] `docker compose up --build` starts all services (PostgreSQL, Valkey, Vault, MIRA)
- [x] Vault unseals correctly on boot and container restart
- [x] Health endpoint returns `{"status": "healthy"}`
- [x] Chat UI loads at `/chat`
- [x] Chat API responds without `NameError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)