### PR TITLE
fix(deploy): harden preflight against common install failures

### DIFF
--- a/deploy/dependencies.sh
+++ b/deploy/dependencies.sh
@@ -177,21 +177,37 @@ elif [ "$OS" = "macos" ]; then
             break
         fi
     done
-    
+
     # If no suitable version found, default to 3.12 for installation
     if [ -z "$PYTHON_VER" ]; then
         PYTHON_VER="3.12"
     fi
 
+    # valkey and redis both install `redis-*` binaries — if redis formula is
+    # present, `brew install valkey` aborts with a conflict error. Unlink redis
+    # preemptively (the formula stays installed; just its symlinks are removed)
+    # so the install can proceed. Users can `brew link redis` later if they
+    # want both around.
+    if brew list --formula 2>/dev/null | grep -q "^redis$"; then
+        echo -ne "${DIM}${ARROW}${RESET} Unlinking redis formula (conflicts with valkey install)... "
+        brew unlink redis > /dev/null 2>&1 || true
+        echo -e "${CHECKMARK}"
+    fi
+
     if [ "$LOUD_MODE" = true ]; then
         print_step "Updating Homebrew..."
-        brew update
+        # Tolerate non-zero exit from `brew update` — a single broken third-party
+        # tap (e.g. one whose remote has been deleted) makes brew update exit
+        # non-zero, which `set -e` would otherwise turn into a silent deploy
+        # abort. The subsequent `brew install` does its own index refresh, so
+        # stale indices aren't actually a concern here.
+        brew update || print_warning "brew update reported errors (continuing; usually a broken tap)"
         print_step "Adding HashiCorp tap..."
         brew tap hashicorp/tap
         print_step "Installing dependencies via Homebrew (Python ${PYTHON_VER})..."
         brew install python@${PYTHON_VER} wget curl postgresql@17 pgvector valkey hashicorp/tap/vault
     else
-        (brew update > /dev/null 2>&1) &
+        (brew update > /dev/null 2>&1 || true) &
         show_progress $! "Updating Homebrew"
 
         (brew tap hashicorp/tap > /dev/null 2>&1) &

--- a/deploy/finalize.sh
+++ b/deploy/finalize.sh
@@ -247,4 +247,26 @@ if [ "$OS" = "macos" ]; then
     print_info "PostgreSQL and Valkey are managed by brew services"
 fi
 
+# Degraded-mode banner: subcortical runs on every user turn for entity
+# extraction / passage filtering / query expansion. Without a key, those calls
+# silently no-op, which looks like working MIRA until a user wonders why
+# recall is poor. Announce the state loudly at the end so it can't be missed.
+if [ "${CONFIG_SUBCORTICAL_API_KEY}" = "PLACEHOLDER_SET_THIS_LATER" ]; then
+    echo ""
+    echo -e "${BOLD}${YELLOW}╔════════════════════════════════════════════════════════╗${RESET}"
+    echo -e "${BOLD}${YELLOW}║  MIRA installed, but running in DEGRADED MODE          ║${RESET}"
+    echo -e "${BOLD}${YELLOW}╚════════════════════════════════════════════════════════╝${RESET}"
+    print_warning "No subcortical API key was configured."
+    print_info "Entity extraction, passage filtering, and query expansion"
+    print_info "will silently no-op on every conversation turn — memory"
+    print_info "retrieval will be noticeably less accurate."
+    echo ""
+    print_info "To enable, store your Groq key in Vault:"
+    echo -e "${DIM}    export VAULT_ADDR='http://127.0.0.1:8200'${RESET}"
+    echo -e "${DIM}    vault login \$(grep 'Initial Root Token' /opt/vault/init-keys.txt | awk '{print \$NF}')${RESET}"
+    echo -e "${DIM}    vault kv patch secret/mira/api_keys subcortical_key=\"gsk_...\"${RESET}"
+    echo ""
+    print_info "Then restart MIRA to pick up the new key."
+fi
+
 echo ""


### PR DESCRIPTION
## Summary
Three small, independent install-UX fixes bundled together. All hit during a fresh macOS install, all relevant to the issues flagged in #48.

### 1. redis/valkey brew conflict
`brew install valkey` aborts when the `redis` formula is also installed, because both own `redis-*` symlinks (`/opt/homebrew/bin/redis-server`, etc). On a reasonably-loaded mac this is common and causes the deploy to die mid-install.

Fix: before `brew install`, check for an installed `redis` formula and run `brew unlink redis`. The formula stays installed; only its symlinks get removed. Users can `brew link redis` later if they want both around.

### 2. `brew update` silent death on broken third-party taps
A single broken tap anywhere in the user's brew install (I had `anthropics/claude` — remote repo deleted) makes `brew update` exit non-zero. `set -e` then kills `deploy.sh` with no banner — just a `fatal: couldn't find remote ref refs/heads/main` buried in hundreds of lines of brew output and a returned shell prompt.

Fix: tolerate non-zero exit from `brew update` and emit a visible warning noting the usual cause. The subsequent `brew install` does its own index refresh so stale indices aren't a concern.

### 3. Skipped subcortical key produces a silent degraded install
If the user presses Enter through the subcortical prompt, `CONFIG_SUBCORTICAL_API_KEY` becomes `PLACEHOLDER_SET_THIS_LATER`. There's an existing warning in `finalize.sh`'s Provider Configuration block, but it's easy to miss among the other success output. MIRA then boots and *appears* to work, but subcortical calls silently no-op on every turn — entity extraction, passage filtering, and query expansion all return nothing, materially degrading memory retrieval.

Fix: add a prominent end-of-deploy banner when the placeholder is detected, explaining what will silently no-op and how to patch the key into Vault later.

## Scope
Does not touch:
- Linux path (dependencies.sh Linux block unchanged)
- The `VAULT_ADDR` launcher fix (separate PR #49)
- The port-conflict / Docker detection / python.sh-download-source items from #48 — those are opinionated enough to deserve their own discussion

## Test plan
- [x] Reproduced all three failures on macOS 24.x / Apple Silicon with a clean checkout:
  - broken `anthropics/claude` tap in brew → confirmed silent deploy exit in LOUD mode
  - `redis` formula installed → confirmed `brew install valkey` failure
  - skipped subcortical key → confirmed install completes with only a mid-output warning
- [x] Applied this patch and verified each path:
  - broken tap: `brew update` emits the visible warning but install continues to completion
  - redis present: unlink step runs cleanly, valkey installs without conflict
  - skipped subcortical: final banner prints and is impossible to miss
- [x] Re-linked redis and confirmed nothing in MIRA broke afterward (redis and valkey coexist fine once unlinked)
- [ ] Not tested: Linux path (no behavior change — all edits are inside the macOS `elif` block or check `CONFIG_SUBCORTICAL_API_KEY` which is OS-agnostic)

Related to #48.