### PR TITLE
feat(api): optional per-request cost feedback via show_cost flag

### DIFF
--- a/clients/llm_provider.py
+++ b/clients/llm_provider.py
@@ -680,6 +680,23 @@ class LLMProvider:
         except Exception as e:
             self.logger.error(f"Billing on cancel failed: {e}", exc_info=True)
 
+        # Cost accumulator hook (independent of billing module — active when a
+        # request handler has opted into per-request cost feedback).
+        try:
+            from utils import cost_accumulator
+            snapshot = getattr(stream, 'current_message_snapshot', None)
+            if cost_accumulator.is_active() and snapshot and getattr(snapshot, 'usage', None):
+                cost_accumulator.record(
+                    internal_llm_name=None,  # stream cancellation only occurs on user-tier chat
+                    model=model,
+                    input_tokens=snapshot.usage.input_tokens,
+                    output_tokens=max(streamed_output_chars // 4, 1),
+                    cache_read_tokens=getattr(snapshot.usage, 'cache_read_input_tokens', 0) or 0,
+                    cache_write_tokens=getattr(snapshot.usage, 'cache_creation_input_tokens', 0) or 0,
+                )
+        except Exception as e:
+            self.logger.debug(f"cost_accumulator record failed (non-fatal): {e}")
+
     def _prepare_tools_for_caching(self, tools: List[Dict]) -> List[Dict]:
         """
         Prepare tools for prompt caching by marking the last tool.
@@ -852,6 +869,7 @@ class LLMProvider:
                 max_tokens=max_tokens,
                 container_id=container_id,
                 allow_negative=allow_negative,
+                internal_llm_name=_llm_cfg.name if _llm_cfg else None,
             )
 
         # Streaming path
@@ -1184,6 +1202,22 @@ class LLMProvider:
                             pass  # OSS mode
                         self.logger.error(f"Billing record_usage failed (generic streaming): {e}", exc_info=True)
 
+                    # Cost accumulator hook (stream_events never carries internal_llm context —
+                    # it's only called from the user-facing chat path).
+                    try:
+                        from utils import cost_accumulator
+                        if cost_accumulator.is_active() and response.usage:
+                            cost_accumulator.record(
+                                internal_llm_name=None,
+                                model=model_override,
+                                input_tokens=response.usage.input_tokens,
+                                output_tokens=response.usage.output_tokens,
+                                cache_read_tokens=getattr(response.usage, 'cache_read_input_tokens', 0) or 0,
+                                cache_write_tokens=getattr(response.usage, 'cache_creation_input_tokens', 0) or 0,
+                            )
+                    except Exception as e:
+                        self.logger.debug(f"cost_accumulator record failed (non-fatal): {e}")
+
                     # Check for tool_use blocks
                     tool_blocks = [b for b in response.content if b.type == "tool_use"]
 
@@ -1359,6 +1393,7 @@ class LLMProvider:
         max_tokens: Optional[int] = None,
         container_id: Optional[str] = None,
         allow_negative: bool = False,
+        internal_llm_name: Optional[str] = None,
     ) -> anthropic.types.Message:
         """Non-streaming generation with Anthropic SDK or generic provider - returns Message object."""
         try:
@@ -1678,6 +1713,21 @@ class LLMProvider:
                     pass  # OSS mode - no billing exceptions module
                 self.logger.error(f"Billing record_usage failed: {e}", exc_info=True)
 
+            # Cost accumulator hook (independent of billing module).
+            try:
+                from utils import cost_accumulator
+                if cost_accumulator.is_active() and hasattr(message, 'usage') and message.usage:
+                    cost_accumulator.record(
+                        internal_llm_name=internal_llm_name,
+                        model=selected_model,
+                        input_tokens=message.usage.input_tokens,
+                        output_tokens=message.usage.output_tokens,
+                        cache_read_tokens=getattr(message.usage, 'cache_read_input_tokens', 0) or 0,
+                        cache_write_tokens=getattr(message.usage, 'cache_creation_input_tokens', 0) or 0,
+                    )
+            except Exception as e:
+                self.logger.debug(f"cost_accumulator record failed (non-fatal): {e}")
+
             return message
 
         except anthropic.APITimeoutError:
@@ -1961,6 +2011,21 @@ class LLMProvider:
                             except ImportError:
                                 pass  # OSS mode - no billing exceptions module
                             self.logger.error(f"Billing record_usage failed: {e}", exc_info=True)
+
+                        # Cost accumulator hook (stream_events is always user-tier chat).
+                        try:
+                            from utils import cost_accumulator
+                            if cost_accumulator.is_active() and hasattr(final_message, 'usage') and final_message.usage:
+                                cost_accumulator.record(
+                                    internal_llm_name=None,
+                                    model=selected_model,
+                                    input_tokens=final_message.usage.input_tokens,
+                                    output_tokens=final_message.usage.output_tokens,
+                                    cache_read_tokens=getattr(final_message.usage, 'cache_read_input_tokens', 0) or 0,
+                                    cache_write_tokens=getattr(final_message.usage, 'cache_creation_input_tokens', 0) or 0,
+                                )
+                        except Exception as e:
+                            self.logger.debug(f"cost_accumulator record failed (non-fatal): {e}")
 
                         # Emit ToolCompletedEvent for server-side tools so the
                         # orchestrator can persist tool history across turns.

--- a/cns/api/chat.py
+++ b/cns/api/chat.py
@@ -59,6 +59,7 @@ class ChatRequest(BaseModel):
     document: str | None = Field(None, description="Optional document as base64 string")
     document_type: str | None = Field(None, description="MIME type for document (e.g., application/pdf)")
     include_thinking: bool = Field(False, description="Include thinking trace in response")
+    show_cost: bool = Field(False, description="Include per-request token usage and USD cost in the response under `data.cost`")
 
 
 class ChatEndpoint(BaseHandler):
@@ -74,6 +75,7 @@ class ChatEndpoint(BaseHandler):
         document: str | None,
         document_type: str | None,
         include_thinking: bool = False,
+        show_cost: bool = False,
     ) -> SuccessResponse:
         start_time = utc_now()
 
@@ -269,6 +271,14 @@ class ChatEndpoint(BaseHandler):
             # Create a Unit of Work and process via orchestrator
             uow = continuum_pool.begin_work(continuum)
 
+            # Per-request cost tracking (opt-in). Started before any LLM calls
+            # fire (including subcortical and internal_llm purposes), drained
+            # after the orchestrator returns so the summary covers every call
+            # the turn triggered.
+            if show_cost:
+                from utils import cost_accumulator
+                cost_accumulator.start()
+
             from config.config_manager import config as app_config
             continuum, response_text, metadata = orchestrator.process_message(
                 continuum,
@@ -283,6 +293,13 @@ class ChatEndpoint(BaseHandler):
 
             # Commit batched changes
             uow.commit()
+
+            cost_summary = None
+            if show_cost:
+                from utils import cost_accumulator
+                summary = cost_accumulator.drain()
+                if summary is not None:
+                    cost_summary = summary.to_dict()
 
             processing_time_ms = int((utc_now() - start_time).total_seconds() * 1000)
 
@@ -299,6 +316,8 @@ class ChatEndpoint(BaseHandler):
             }
             if include_thinking and metadata.get("thinking"):
                 data["thinking"] = metadata["thinking"]
+            if cost_summary is not None:
+                data["cost"] = cost_summary
 
             return create_success_response(
                 data=data,
@@ -332,6 +351,7 @@ def chat_endpoint(
             document=request.document,
             document_type=request.document_type,
             include_thinking=request.include_thinking,
+            show_cost=request.show_cost,
         )
         return response.to_dict()
 

--- a/deploy/oss_ui/chat.html
+++ b/deploy/oss_ui/chat.html
@@ -321,6 +321,18 @@ header h1 {
   font-family: 'IBM Plex Mono', monospace;
 }
 
+/* Cost footer on assistant replies (shown only when `Cost: on`) */
+.cost-footer {
+  margin-top: 8px;
+  font-size: 11px;
+  opacity: 0.55;
+  font-family: 'IBM Plex Mono', Menlo, monospace;
+  letter-spacing: 0.02em;
+}
+
+/* Cost toggle button active state */
+#cost-toggle.active { color: var(--lime); border-color: rgba(0,255,0,0.35); }
+
 /* Tool badges */
 .msg-tools { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 4px; }
 .tool-badge {
@@ -621,6 +633,7 @@ header h1 {
   <h1><a href="https://miraos.org/" target="_blank" style="color:var(--lime);text-decoration:none">MIRA</a> <span style="opacity:0.4;font-weight:400">OPEN SOURCE UI</span></h1>
   <button id="domain-toggle" onclick="toggleDomainPanel()"><span id="domain-status">Domains</span></button>
   <button id="rules-toggle" onclick="toggleRulesModal()" style="margin-left:0">Rules</button>
+  <button id="cost-toggle" onclick="toggleShowCost()" style="margin-left:0" title="Show per-request token usage and cost">Cost: off</button>
   <span id="key-status" onclick="promptForKey()">No API key</span>
 </header>
 
@@ -715,6 +728,39 @@ let hasMore = false;
 let sending = false;
 let domains = [];
 let domainPanelOpen = false;
+let showCost = localStorage.getItem('mira_show_cost') === '1';
+
+function toggleShowCost() {
+  showCost = !showCost;
+  localStorage.setItem('mira_show_cost', showCost ? '1' : '0');
+  refreshCostToggleLabel();
+}
+
+function refreshCostToggleLabel() {
+  const btn = document.getElementById('cost-toggle');
+  if (!btn) return;
+  btn.textContent = 'Cost: ' + (showCost ? 'on' : 'off');
+  btn.classList.toggle('active', showCost);
+}
+
+function formatCostFooter(cost) {
+  if (!cost) return '';
+  const n = (v) => (v || 0).toLocaleString();
+  const dollarStr = cost.cost_usd >= 0.01
+    ? '$' + cost.cost_usd.toFixed(4)
+    : '$' + cost.cost_usd.toFixed(6);
+  const parts = [
+    `${n(cost.input_tokens)} in`,
+    `${n(cost.output_tokens)} out`,
+  ];
+  if (cost.cache_read_tokens) parts.push(`${n(cost.cache_read_tokens)} cache-hit`);
+  if (cost.cache_write_tokens) parts.push(`${n(cost.cache_write_tokens)} cache-write`);
+  parts.push(dollarStr);
+  if (cost.calls > 1) parts.push(`${cost.calls} calls`);
+  if (cost.unpriced_calls) parts.push(`${cost.unpriced_calls} unpriced`);
+  const marker = cost.fallback_prices_used ? ' · est.' : '';
+  return parts.join(' · ') + marker;
+}
 
 // ─── Auth ───────────────────────────────────────
 async function tryAutoLogin() {
@@ -933,15 +979,25 @@ async function send() {
   document.getElementById('loading').classList.add('active');
 
   try {
+    const body = { message: text };
+    if (showCost) body.show_cost = true;
     const r = await apiFetch(`${API}/chat`, {
       method: 'POST',
-      body: JSON.stringify({ message: text })
+      body: JSON.stringify(body)
     });
     if (r.status === 401) { promptForKey(); return; }
     const json = await r.json();
     const response = json.data?.response || json.response || 'No response';
     const toolsUsed = json.data?.metadata?.tools_used || [];
-    container.appendChild(createMsgEl('assistant', response, new Date().toISOString(), toolsUsed));
+    const msgEl = createMsgEl('assistant', response, new Date().toISOString(), toolsUsed);
+    const costData = json.data?.cost;
+    if (costData) {
+      const costEl = document.createElement('div');
+      costEl.className = 'cost-footer';
+      costEl.textContent = formatCostFooter(costData);
+      msgEl.appendChild(costEl);
+    }
+    container.appendChild(msgEl);
     scrollToBottom();
   } catch (e) {
     container.appendChild(createMsgEl('assistant', 'Error: Could not reach MIRA. Check your connection.', null));
@@ -1294,6 +1350,7 @@ function dismissBanner(permanent) {
 
 // ─── Startup ────────────────────────────────────
 (async () => {
+  refreshCostToggleLabel();
   if (await checkAuth()) {
     loadHistory();
     fetchDomains();

--- a/utils/cost_accumulator.py
+++ b/utils/cost_accumulator.py
@@ -1,0 +1,258 @@
+"""
+Per-request LLM cost accumulator for user-facing "what did this cost" feedback.
+
+A request handler (typically `cns/api/chat.py`) calls `start()` when the user
+has asked to see cost. Every LLM call site in `clients/llm_provider.py` then
+calls `record()` with the call's token usage and context (`internal_llm` name
+if applicable). At the end of the request the handler calls `drain()` which
+returns a structured summary.
+
+Pricing is looked up from the `usage_pricing` table. Rows with NULL prices
+fall back to `FALLBACK_PRICES` below — keeps the feature useful in OSS where
+the closed `billing` module isn't present to auto-populate from OpenRouter.
+
+The accumulator is scoped to a contextvar, so call-site code can be ignorant
+of whether cost tracking is active — `record()` is a no-op when it isn't.
+"""
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Dict, List, Optional, TypedDict
+
+from utils.database_session_manager import get_shared_session_manager
+
+
+# Public pricing as of 2026-04. Used only when `usage_pricing` has NULL for a
+# key the user exercised. Values are USD per million tokens.
+# Updating this table is a low-risk change; Anthropic and Groq publish their
+# prices openly. A hosted install with a real billing backend will have
+# populated `usage_pricing` rows and never hit this fallback.
+FALLBACK_PRICES: Dict[str, Dict[str, float]] = {
+    # Anthropic Claude
+    "claude-opus-4-6":           {"input": 15.00, "output": 75.00, "cache_read": 1.50,  "cache_write": 18.75},
+    "claude-sonnet-4-6":         {"input":  3.00, "output": 15.00, "cache_read": 0.30,  "cache_write":  3.75},
+    "claude-haiku-4-5":          {"input":  1.00, "output":  5.00, "cache_read": 0.10,  "cache_write":  1.25},
+    "claude-haiku-4-5-20251001": {"input":  1.00, "output":  5.00, "cache_read": 0.10,  "cache_write":  1.25},
+    # Groq (subcortical)
+    "qwen/qwen3-32b":            {"input":  0.29, "output":  0.39, "cache_read": 0.0,   "cache_write":  0.0},
+}
+
+
+class _UsageRecord(TypedDict):
+    pricing_key: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+
+
+@dataclass(frozen=True)
+class CostSummary:
+    """Structured cost summary for a single request."""
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+    cost_usd: float
+    calls: int
+    unpriced_calls: int
+    fallback_prices_used: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_write_tokens": self.cache_write_tokens,
+            "cost_usd": round(self.cost_usd, 6),
+            "calls": self.calls,
+            "unpriced_calls": self.unpriced_calls,
+            "fallback_prices_used": self.fallback_prices_used,
+        }
+
+
+_records: ContextVar[Optional[List[_UsageRecord]]] = ContextVar(
+    "cost_accumulator_records", default=None
+)
+
+
+def start() -> None:
+    """Begin accumulating usage records for the current request."""
+    _records.set([])
+
+
+def is_active() -> bool:
+    """True if the accumulator has been started for the current request."""
+    return _records.get() is not None
+
+
+def record(
+    *,
+    internal_llm_name: Optional[str],
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+) -> None:
+    """Append a usage record. No-op if no accumulator is active.
+
+    `internal_llm_name` is the `internal_llm` purpose key (e.g. `"summary"`)
+    when the call was made with `internal_llm=...`, or None when the call
+    used the user's account tier (regular user-facing chat).
+    """
+    records = _records.get()
+    if records is None:
+        return
+    pricing_key = _resolve_pricing_key(internal_llm_name)
+    if pricing_key is None:
+        # Called outside user context (rare — startup, admin jobs). Skip silently;
+        # cost tracking is only meaningful inside a user request anyway.
+        return
+    records.append(_UsageRecord(
+        pricing_key=pricing_key,
+        model=model,
+        input_tokens=int(input_tokens or 0),
+        output_tokens=int(output_tokens or 0),
+        cache_read_tokens=int(cache_read_tokens or 0),
+        cache_write_tokens=int(cache_write_tokens or 0),
+    ))
+
+
+def drain() -> Optional[CostSummary]:
+    """Consume the accumulator and return a priced summary.
+
+    Returns None if no accumulator was active. The accumulator is always
+    cleared, even on partial pricing data.
+    """
+    records = _records.get()
+    _records.set(None)
+    if not records:
+        return None
+
+    prices = _fetch_prices({r["pricing_key"] for r in records})
+
+    total_in = sum(r["input_tokens"] for r in records)
+    total_out = sum(r["output_tokens"] for r in records)
+    total_cr = sum(r["cache_read_tokens"] for r in records)
+    total_cw = sum(r["cache_write_tokens"] for r in records)
+
+    total_cost = 0.0
+    unpriced = 0
+    used_fallback = False
+
+    for r in records:
+        db_price = prices.get(r["pricing_key"])
+        price, is_fallback = _price_for_record(db_price, r["model"])
+        if price is None:
+            unpriced += 1
+            continue
+        if is_fallback:
+            used_fallback = True
+        total_cost += (
+            (r["input_tokens"]       / 1_000_000) * price["input"] +
+            (r["output_tokens"]      / 1_000_000) * price["output"] +
+            (r["cache_read_tokens"]  / 1_000_000) * price["cache_read"] +
+            (r["cache_write_tokens"] / 1_000_000) * price["cache_write"]
+        )
+
+    return CostSummary(
+        input_tokens=total_in,
+        output_tokens=total_out,
+        cache_read_tokens=total_cr,
+        cache_write_tokens=total_cw,
+        cost_usd=total_cost,
+        calls=len(records),
+        unpriced_calls=unpriced,
+        fallback_prices_used=used_fallback,
+    )
+
+
+def _resolve_pricing_key(internal_llm_name: Optional[str]) -> Optional[str]:
+    """Compute the `usage_pricing.name` for the call being recorded.
+
+    Internal LLM purposes key by "{name}:{tier}" (e.g. "summary:cof");
+    user-facing chat keys by the user's `account_tiers.name` (e.g. "primary").
+    Returns None when there is no active user context.
+    """
+    from utils.user_context import has_user_context, get_current_user_id, _resolve_user_internal_tier
+
+    if not has_user_context():
+        return None
+
+    if internal_llm_name is not None:
+        return f"{internal_llm_name}:{_resolve_user_internal_tier()}"
+
+    # User-tier chat — read llm_tier from the users row.
+    from clients.postgres_client import PostgresClient
+    db = PostgresClient("mira_service", admin=True)
+    row = db.execute_single(
+        "SELECT llm_tier FROM users WHERE id = %(id)s",
+        {"id": str(get_current_user_id())},
+    )
+    return row["llm_tier"] if row else None
+
+
+def _fetch_prices(keys: set[str]) -> Dict[str, Optional[Dict[str, Optional[float]]]]:
+    """Return {pricing_key: price_dict_or_None} for the given keys.
+
+    Each price_dict has 'input'/'output'/'cache_read'/'cache_write' floats, any
+    of which may be None if that column is NULL. Keys with no row at all map
+    to None.
+    """
+    if not keys:
+        return {}
+    with get_shared_session_manager().get_admin_session() as session:
+        rows = session.execute_query(
+            """SELECT name,
+                      input_price_per_mtok,
+                      output_price_per_mtok,
+                      cache_read_price_per_mtok,
+                      cache_write_price_per_mtok
+                 FROM usage_pricing
+                WHERE name = ANY(%(keys)s)""",
+            {"keys": list(keys)},
+        )
+    result: Dict[str, Optional[Dict[str, Optional[float]]]] = {k: None for k in keys}
+    for row in rows:
+        result[row["name"]] = {
+            "input":       float(row["input_price_per_mtok"])       if row["input_price_per_mtok"]       is not None else None,
+            "output":      float(row["output_price_per_mtok"])      if row["output_price_per_mtok"]      is not None else None,
+            "cache_read":  float(row["cache_read_price_per_mtok"])  if row["cache_read_price_per_mtok"]  is not None else None,
+            "cache_write": float(row["cache_write_price_per_mtok"]) if row["cache_write_price_per_mtok"] is not None else None,
+        }
+    return result
+
+
+def _price_for_record(
+    db_price: Optional[Dict[str, Optional[float]]],
+    model: str,
+) -> tuple[Optional[Dict[str, float]], bool]:
+    """Choose the price to use for a single record.
+
+    Preference order:
+      1. usage_pricing row with all four columns populated.
+      2. FALLBACK_PRICES by model name.
+      3. None — record is unpriced and will be counted but not costed.
+
+    Returns (price_dict, is_fallback). `price_dict` always has all four
+    fields as concrete floats when not None.
+    """
+    if db_price is not None and all(
+        db_price.get(k) is not None for k in ("input", "output", "cache_read", "cache_write")
+    ):
+        return (
+            {
+                "input":       db_price["input"],       # type: ignore[typeddict-item]
+                "output":      db_price["output"],      # type: ignore[typeddict-item]
+                "cache_read":  db_price["cache_read"],  # type: ignore[typeddict-item]
+                "cache_write": db_price["cache_write"], # type: ignore[typeddict-item]
+            },
+            False,
+        )
+    fallback = FALLBACK_PRICES.get(model)
+    if fallback is not None:
+        return (dict(fallback), True)
+    return (None, False)


### PR DESCRIPTION
## Summary
Adds an opt-in per-request cost summary. When `ChatRequest.show_cost = true`, the `/chat` endpoint returns a `data.cost` object with tokens and USD cost for every LLM call the turn triggered — subcortical + main chat + any internal_llm purposes (peanut gallery, etc.).

The OSS chat UI gets a header toggle button (`Cost: on/off`, persisted in localStorage). When on, each assistant reply gets a small muted footer:

```
23,456 in · 847 out · 18,000 cache-hit · $0.0156 · 3 calls · est.
```

The `est.` marker appears when fallback prices were used (see below).

## Why
Users on `primary` chat with the full memory pipeline don't have an easy way to see what a single turn actually costs. The `billing` module does the per-turn accounting but isn't in OSS, and its output targets invoicing (persists records, debits balance), not user-facing feedback. This feature adds a lightweight parallel path that answers "what did that message just cost me?" without touching the billing codepath.

## Implementation

### `utils/cost_accumulator.py` (new, ~230 lines)
Contextvar-scoped accumulator. `start()` initializes it for a request; each LLM call site in `LLMProvider` calls `record()` (no-op when no accumulator is active); the request handler calls `drain()` for a priced summary. Scoping via contextvar means LLM sites can be ignorant of whether tracking is on.

### `clients/llm_provider.py` (+~65 lines)
Four cost hooks added next to the existing `billing.record_usage` hooks:
- generic-provider streaming
- non-streaming Anthropic
- Anthropic streaming  
- `_bill_cancelled_stream` for cancellation accounting

Pricing key resolution: `_generate_non_streaming` gets a new `internal_llm_name` kwarg so stack-deep calls resolve to the right `usage_pricing` row. `generate_response` passes `_llm_cfg.name if _llm_cfg else None`. `stream_events` calls hardcode `None` since user-tier chat is the only caller.

### `cns/api/chat.py` (+~20 lines)
`ChatRequest.show_cost` field; `cost_accumulator.start()` before orchestrator and `.drain()` after; `cost` field added to `data`.

### `deploy/oss_ui/chat.html` (+~60 lines net)
Header toggle button, per-reply footer rendering, localStorage persistence.

## Pricing sources (priority order)

1. **`usage_pricing` row with all four columns populated** — billing-owned path, used when the closed billing module has populated prices.
2. **`FALLBACK_PRICES` constant** in `cost_accumulator.py` — Anthropic Claude and Groq public prices as of 2026-04. Marked `est.` in the UI footer when used. Keeps the feature useful in OSS without requiring manual SQL setup.
3. **Unpriced** — tokens still reported, cost skipped, flagged via `unpriced_calls` count.

### Why duplicate pricing tables?
The closed `billing` module auto-populates `usage_pricing` from OpenRouter at startup; OSS never populates those rows, so `usage_pricing.*_price_per_mtok` is NULL out-of-the-box. Rather than fail silently (and confuse the user into thinking their feature is broken), the fallback table keeps dollar output working in the default OSS configuration. Hosted/production installs with real prices in `usage_pricing` take priority automatically.

## Scope
- Only the non-streaming HTTP `/chat` endpoint. The WebSocket streaming endpoint (`cns/api/websocket_chat.py`) is not covered — it would need a separate streaming-final-event for cost, which is follow-up work.
- No persistence. Cost info is returned to the caller of the single request; nothing is stored server-side.
- No changes to `billing` hooks — cost_accumulator runs in parallel and doesn't interfere with billing.

## Test plan
- [x] Toggle off → request body has no `show_cost`, response has no `data.cost`. Confirms opt-in.
- [x] Toggle on, simple message → single turn's usage appears: subcortical call (Groq) + main chat call. Dollar amount matches hand calculation for Sonnet at stated tokens.
- [x] Toggle on, message that triggers a tool call → multiple calls summed.
- [x] Toggle on in a cache-warm session → `cache_read_tokens` populated, dollar cost materially lower.
- [x] Toggle on with `usage_pricing` NULL (default OSS) → footer shows `est.` marker; cost computed from `FALLBACK_PRICES`.
- [x] Toggle on with `usage_pricing` populated → `est.` marker absent; cost computed from DB prices.
- [x] Model without a `FALLBACK_PRICES` entry → `unpriced_calls` counted; tokens still shown.
- [ ] Not tested: WebSocket endpoint (intentionally out of scope).
- [ ] Not tested: behavior when called concurrently — contextvar scopes correctly per FastAPI request, but I haven't stress-tested parallel requests from the same user.

## Follow-ups (intentionally separate PRs)
- WebSocket streaming support (final event carrying the cost summary).
- OpenRouter price auto-population for OSS (would remove the need for `FALLBACK_PRICES`).
- CLI (`mira cost`) for querying cost outside a chat session.