### PR TITLE
feat: multi-instance support via MIRA_INSTANCE env var

### DIFF
--- a/clients/hybrid_embeddings_provider.py
+++ b/clients/hybrid_embeddings_provider.py
@@ -47,7 +47,7 @@ class EmbeddingCache:
         Raises if Valkey operation fails.
         """
         cache_key = self._get_cache_key(text)
-        cached_data = self.valkey.valkey_binary.get(cache_key)
+        cached_data = self.valkey.binary_get(cache_key)
         if cached_data:
             return np.frombuffer(cached_data, dtype=np.float16)
 
@@ -61,7 +61,7 @@ class EmbeddingCache:
         """
         cache_key = self._get_cache_key(text)
         embedding_bytes = embedding.astype(np.float16).tobytes()
-        self.valkey.valkey_binary.setex(cache_key, 900, embedding_bytes)
+        self.valkey.binary_setex(cache_key, 900, embedding_bytes)
 
 
 def get_hybrid_embeddings_provider(cache_enabled: bool = True) -> 'HybridEmbeddingsProvider':

--- a/clients/llm_provider.py
+++ b/clients/llm_provider.py
@@ -414,7 +414,8 @@ class LLMProvider:
             raise ValueError(f"File too large: {size_bytes} bytes (max {MAX_FILE_ARTIFACT_SIZE})")
 
         user_id = str(get_current_user_id())
-        artifacts_dir = Path("data/users") / user_id / "artifacts"
+        from utils.instance import user_data_base
+        artifacts_dir = user_data_base() / user_id / "artifacts"
         artifacts_dir.mkdir(parents=True, exist_ok=True)
 
         safe_filename = sanitize_filename(filename)

--- a/clients/postgres_client.py
+++ b/clients/postgres_client.py
@@ -78,8 +78,9 @@ class PostgresClient:
         )
 
     def _needs_vector(self) -> bool:
-        """mira_service stores embeddings/vectors (memories, entities, messages)."""
-        return self.database_name == 'mira_service'
+        """mira_service (any instance) stores embeddings/vectors."""
+        from utils.instance import database_name
+        return self.database_name == database_name()
 
     def _ensure_connection_pool(self):
         """Ensure connection pool exists for this database."""

--- a/clients/valkey_client.py
+++ b/clients/valkey_client.py
@@ -31,6 +31,13 @@ class ValkeyClient:
         self._load_config()
         self._init_connections()
 
+        from utils.instance import valkey_prefix
+        self._prefix = valkey_prefix()
+
+    def _key(self, key: str) -> str:
+        """Apply instance prefix to key. No-op for default instance."""
+        return f"{self._prefix}{key}" if self._prefix else key
+
     def _load_config(self):
         """Load Valkey URL and password from Vault. Raises if Vault is unavailable."""
         from urllib.parse import urlparse
@@ -132,7 +139,7 @@ class ValkeyClient:
         Returns None if key doesn't exist.
         Raises if Valkey connection fails.
         """
-        return self._client.get(key)
+        return self._client.get(self._key(key))
 
     def delete(self, key: str) -> bool:
         """
@@ -141,7 +148,7 @@ class ValkeyClient:
         Returns True if key was deleted, False if key didn't exist.
         Raises if Valkey connection fails.
         """
-        result = self._client.delete(key)
+        result = self._client.delete(self._key(key))
         return result > 0
 
     def exists(self, key: str) -> bool:
@@ -151,7 +158,7 @@ class ValkeyClient:
         Returns True if key exists, False if not.
         Raises if Valkey connection fails.
         """
-        result = self._client.exists(key)
+        result = self._client.exists(self._key(key))
         return result > 0
 
     def ttl(self, key: str) -> int:
@@ -161,7 +168,7 @@ class ValkeyClient:
         Returns -1 if key has no TTL, -2 if key doesn't exist.
         Raises if Valkey connection fails.
         """
-        return self._client.ttl(key)
+        return self._client.ttl(self._key(key))
 
     def scan(self, cursor: int, match: Optional[str] = None, count: int = 100) -> tuple[int, list[str]]:
         """
@@ -170,17 +177,24 @@ class ValkeyClient:
         Returns (next_cursor, keys) tuple.
         Raises if Valkey connection fails.
         """
-        return self._client.scan(cursor, match=match, count=count)
+        if match and self._prefix:
+            match = f"{self._prefix}{match}"
+        elif self._prefix:
+            match = f"{self._prefix}*"
+        next_cursor, keys = self._client.scan(cursor, match=match, count=count)
+        if self._prefix:
+            keys = [k[len(self._prefix):] for k in keys]
+        return next_cursor, keys
 
     def increment_with_expiry(self, key: str, expiry_seconds: int) -> int:
         """Atomic increment with expiration - ideal for rate limiting."""
-        # First increment the counter
-        count = self._client.incr(key)
+        prefixed = self._key(key)
+        count = self._client.incr(prefixed)
 
         # Only set expiry if this is the first increment (count == 1)
         # This prevents resetting the TTL window on every request
         if count == 1:
-            self._client.expire(key, expiry_seconds)
+            self._client.expire(prefixed, expiry_seconds)
 
         return count
 
@@ -200,18 +214,20 @@ class ValkeyClient:
         Returns:
             True if successful, False if key doesn't exist (for field updates)
         """
+        prefixed = self._key(key)
         if path == "$":
             # Full replacement
             json_data = json.dumps(value)
             if ex is not None:
-                return self._client.setex(key, ex, json_data)
+                return self._client.setex(prefixed, ex, json_data)
             else:
-                return self._client.set(key, json_data)
+                return self._client.set(prefixed, json_data)
 
         # Field update: read-modify-write
         if not path.startswith("$."):
             raise ValueError(f"Unsupported path: {path}. Use '$' or '$.field_name'")
 
+        # self.json_get and self.ttl apply prefix internally — pass bare key
         current = self.json_get(key, "$")
         if current is None:
             return False
@@ -227,9 +243,9 @@ class ValkeyClient:
 
         json_data = json.dumps(data)
         if ex is not None:
-            return self._client.setex(key, ex, json_data)
+            return self._client.setex(prefixed, ex, json_data)
         else:
-            return self._client.set(key, json_data)
+            return self._client.set(prefixed, json_data)
 
     def json_set_with_expiry(self, key: str, path: str, value: Dict[str, Any], ex: int) -> bool:
         """Set JSON data with expiration. Alias for json_set with required ex."""
@@ -237,7 +253,7 @@ class ValkeyClient:
 
     def json_get(self, key: str, path: str) -> Optional[list[Dict[str, Any]]]:
         """Get JSON data (returns list format for JSONPath compatibility)."""
-        json_str = self._client.get(key)
+        json_str = self._client.get(self._key(key))
         if json_str is None:
             return None
 
@@ -246,33 +262,36 @@ class ValkeyClient:
 
     def hset_with_retry(self, hash_key: str, field: str, value: str) -> int:
         """Hash set with retry pattern for transient failures."""
+        prefixed = self._key(hash_key)
         try:
-            return self._client.hset(hash_key, field, value)
+            return self._client.hset(prefixed, field, value)
         except Exception as e:
             logger.warning(f"Valkey write failed, retrying: {e}", exc_info=True)
 
         time.sleep(0.1)
-        return self._client.hset(hash_key, field, value)  # Raises on failure
+        return self._client.hset(prefixed, field, value)  # Raises on failure
 
     def hget_with_retry(self, hash_key: str, field: str) -> Optional[str]:
         """Hash get with retry pattern for transient failures."""
+        prefixed = self._key(hash_key)
         try:
-            return self._client.hget(hash_key, field)
+            return self._client.hget(prefixed, field)
         except Exception as e:
             logger.warning(f"Valkey read failed, retrying: {e}", exc_info=True)
 
         time.sleep(0.1)
-        return self._client.hget(hash_key, field)
+        return self._client.hget(prefixed, field)
 
     def hdel_with_retry(self, hash_key: str, *fields) -> int:
         """Hash delete with retry pattern for transient failures."""
+        prefixed = self._key(hash_key)
         try:
-            return self._client.hdel(hash_key, *fields)
+            return self._client.hdel(prefixed, *fields)
         except Exception as e:
             logger.warning(f"Valkey delete failed, retrying: {e}", exc_info=True)
 
         time.sleep(0.1)
-        return self._client.hdel(hash_key, *fields)
+        return self._client.hdel(prefixed, *fields)
 
     def set(self, key: str, value: str, nx: Optional[bool] = None, ex: Optional[int] = None) -> bool:
         """
@@ -294,19 +313,27 @@ class ValkeyClient:
             kwargs['nx'] = nx
         if ex is not None:
             kwargs['ex'] = ex
-        return self._client.set(key, value, **kwargs)
+        return self._client.set(self._key(key), value, **kwargs)
 
     def scan_iter(self, match: Optional[str] = None) -> Iterator[str]:
         """Scan iterator for keys matching pattern."""
-        return self._client.scan_iter(match=match)
+        if match and self._prefix:
+            match = f"{self._prefix}{match}"
+        elif self._prefix:
+            match = f"{self._prefix}*"
+        for key in self._client.scan_iter(match=match):
+            if self._prefix:
+                yield key[len(self._prefix):]
+            else:
+                yield key
 
     def expire(self, key: str, seconds: int) -> bool:
         """Set expiration on key."""
-        return self._client.expire(key, seconds)
+        return self._client.expire(self._key(key), seconds)
 
     def setex(self, key: str, seconds: int, value: str) -> bool:
         """Set key with expiration."""
-        return self._client.setex(key, seconds, value)
+        return self._client.setex(self._key(key), seconds, value)
 
     def rpush(self, key: str, *values: str) -> int:
         """
@@ -323,7 +350,7 @@ class ValkeyClient:
 
         Raises if Valkey connection fails.
         """
-        return self._client.rpush(key, *values)
+        return self._client.rpush(self._key(key), *values)
 
     def lrange(self, key: str, start: int, stop: int) -> list[str]:
         """
@@ -339,7 +366,7 @@ class ValkeyClient:
 
         Raises if Valkey connection fails.
         """
-        return self._client.lrange(key, start, stop)
+        return self._client.lrange(self._key(key), start, stop)
 
     def flush_except_whitelist(self, preserve_prefixes: list[str]) -> int:
         """
@@ -360,10 +387,13 @@ class ValkeyClient:
         deleted_count = 0
         preserved_count = 0
 
-        # Scan all keys
-        for key in self.scan_iter(match="*"):
-            # Check if key starts with any whitelisted prefix
-            should_preserve = any(key.startswith(prefix) for prefix in preserve_prefixes)
+        # When prefixed, only scan our instance's keys
+        scan_pattern = f"{self._prefix}*" if self._prefix else "*"
+
+        for key in self._client.scan_iter(match=scan_pattern):
+            # Strip prefix to check against preserve list
+            bare_key = key[len(self._prefix):] if self._prefix else key
+            should_preserve = any(bare_key.startswith(prefix) for prefix in preserve_prefixes)
 
             if should_preserve:
                 preserved_count += 1

--- a/clients/valkey_client.py
+++ b/clients/valkey_client.py
@@ -125,12 +125,19 @@ class ValkeyClient:
     @property
     def valkey_binary(self) -> "valkey.Valkey":
         """
-        Access the binary client for storing raw bytes (e.g., embeddings).
+        Raw binary client (decode_responses=False). Bypasses instance prefix.
 
-        The binary client has decode_responses=False, preserving bytes as-is
-        without UTF-8 decoding. Used for numpy arrays and other binary data.
+        Prefer binary_get/binary_setex for instance-aware binary operations.
         """
         return self._binary_client
+
+    def binary_get(self, key: str) -> Optional[bytes]:
+        """Get raw bytes by key, with instance prefix applied."""
+        return self._binary_client.get(self._key(key))
+
+    def binary_setex(self, key: str, seconds: int, value: bytes) -> bool:
+        """Set raw bytes with expiration, with instance prefix applied."""
+        return self._binary_client.setex(self._key(key), seconds, value)
 
     def get(self, key: str) -> Optional[str]:
         """

--- a/clients/vault_client.py
+++ b/clients/vault_client.py
@@ -110,62 +110,71 @@ class VaultClient:
 # Individual secret retrieval functions
 def get_database_url(service: str, admin: bool = False) -> str:
     """
-    Get database URL from Vault for mira_service.
+    Get database URL from Vault for the current instance's database.
 
     Args:
-        service: Database service name (only 'mira_service' supported)
+        service: Database service name (must match instance database name)
         admin: If True, returns admin connection string (mira_admin role with BYPASSRLS)
 
     Returns:
         PostgreSQL connection URL
     """
-    if service != 'mira_service':
-        raise ValueError(f"Unknown database service: '{service}'. Only 'mira_service' is supported.")
+    from utils.instance import database_name, vault_prefix
+    expected = database_name()
+    if service != expected:
+        raise ValueError(f"Unknown database service: '{service}'. Expected '{expected}'.")
 
     field = 'admin_url' if admin else 'service_url'
-    cache_key = f"mira/database/{field}"
+    prefix = vault_prefix()
+    cache_key = f"{prefix}/database/{field}"
 
     if cache_key in _secret_cache:
         return _secret_cache[cache_key]
 
     vault_client = _ensure_vault_client()
-    value = vault_client.get_secret('mira/database', field)
+    value = vault_client.get_secret(f'{prefix}/database', field)
     _secret_cache[cache_key] = value
     return value
 
 
 def get_api_key(key_name: str) -> str:
-    cache_key = f"mira/api_keys/{key_name}"
-    
+    from utils.instance import vault_prefix
+    prefix = vault_prefix()
+    cache_key = f"{prefix}/api_keys/{key_name}"
+
     if cache_key in _secret_cache:
         return _secret_cache[cache_key]
-    
+
     vault_client = _ensure_vault_client()
-    value = vault_client.get_secret('mira/api_keys', key_name)
+    value = vault_client.get_secret(f'{prefix}/api_keys', key_name)
     _secret_cache[cache_key] = value
     return value
 
 
 def get_auth_secret(secret_name: str) -> str:
-    cache_key = f"mira/auth/{secret_name}"
-    
+    from utils.instance import vault_prefix
+    prefix = vault_prefix()
+    cache_key = f"{prefix}/auth/{secret_name}"
+
     if cache_key in _secret_cache:
         return _secret_cache[cache_key]
-    
+
     vault_client = _ensure_vault_client()
-    value = vault_client.get_secret('mira/auth', secret_name)
+    value = vault_client.get_secret(f'{prefix}/auth', secret_name)
     _secret_cache[cache_key] = value
     return value
 
 
 def get_service_config(field: str) -> str:
-    cache_key = f"mira/services/{field}"
+    from utils.instance import vault_prefix
+    prefix = vault_prefix()
+    cache_key = f"{prefix}/services/{field}"
 
     if cache_key in _secret_cache:
         return _secret_cache[cache_key]
 
     vault_client = _ensure_vault_client()
-    value = vault_client.get_secret('mira/services', field)
+    value = vault_client.get_secret(f'{prefix}/services', field)
     _secret_cache[cache_key] = value
     return value
 
@@ -178,11 +187,13 @@ def preload_secrets() -> None:
     while the AppRole token is still valid. Raises on any failure —
     missing secrets at startup means scattered failures at runtime.
     """
+    from utils.instance import vault_prefix
+    prefix = vault_prefix()
     vault_client = _ensure_vault_client()
 
     secret_groups = [
-        ('mira/api_keys', 'API keys'),
-        ('mira/database', 'database secrets'),
+        (f'{prefix}/api_keys', 'API keys'),
+        (f'{prefix}/database', 'database secrets'),
     ]
 
     successes = []
@@ -222,8 +233,9 @@ class VaultHealthCheck(TypedDict, total=False):
 # Health check function
 def test_vault_connection() -> VaultHealthCheck:
     try:
+        from utils.instance import vault_prefix
         vault_client = _ensure_vault_client()
-        vault_client.get_secret('mira/database', 'username')
+        vault_client.get_secret(f'{vault_prefix()}/database', 'username')
 
         logger.info("Vault connection test successful")
         return {

--- a/cns/api/actions.py
+++ b/cns/api/actions.py
@@ -982,7 +982,8 @@ class DomainKnowledgeDomainHandler(BaseDomainHandler):
 
     def _get_pg(self):
         from clients.postgres_client import PostgresClient
-        return PostgresClient("mira_service", user_id=str(self.user_id))
+        from utils.instance import database_name
+        return PostgresClient(database_name(), user_id=str(self.user_id))
 
     def _validate_label(self, label: str) -> None:
         """Validate domaindoc label."""

--- a/cns/api/data.py
+++ b/cns/api/data.py
@@ -158,7 +158,8 @@ class DataEndpoint(BaseHandler):
         user_id = get_current_user_id()
 
         # DB health check — let infrastructure failures propagate
-        db = PostgresClient("mira_service", user_id=user_id)
+        from utils.instance import database_name
+        db = PostgresClient(database_name(), user_id=user_id)
         db.execute_single("SELECT 1")
 
         # Context usage metrics are managed by Anthropic's prompt caching
@@ -183,7 +184,8 @@ class DataEndpoint(BaseHandler):
         user_id = get_current_user_id()
 
         # Fetch real user data from database
-        db = PostgresClient("mira_service", user_id=user_id)
+        from utils.instance import database_name
+        db = PostgresClient(database_name(), user_id=user_id)
         user = db.execute_single(
             """SELECT id, email, first_name, last_name, created_at, last_login_at, timezone
                FROM users WHERE id = %(user_id)s""",

--- a/cns/api/files.py
+++ b/cns/api/files.py
@@ -36,7 +36,8 @@ async def download_file(
         raise HTTPException(status_code=400, detail="Invalid file ID")
 
     user_id = current_user.user_id
-    base_dir = (Path("data/users") / user_id / "artifacts" / file_id).resolve()
+    from utils.instance import user_data_base
+    base_dir = (user_data_base() / user_id / "artifacts" / file_id).resolve()
 
     if not base_dir.is_dir():
         raise HTTPException(status_code=404, detail="File not found")
@@ -81,7 +82,8 @@ async def view_image(
         raise HTTPException(status_code=400, detail="Invalid file ID")
 
     user_id = current_user.user_id
-    base_dir = (Path("data/users") / user_id / "artifacts" / file_id).resolve()
+    from utils.instance import user_data_base
+    base_dir = (user_data_base() / user_id / "artifacts" / file_id).resolve()
 
     if not base_dir.is_dir():
         raise HTTPException(status_code=404, detail="Image not found")

--- a/cns/api/health.py
+++ b/cns/api/health.py
@@ -31,9 +31,10 @@ class HealthEndpoint(BaseHandler):
         components: dict[str, dict] = {}
         overall_status = "healthy"
 
-        # Check database connectivity (unified mira_service database)
+        # Check database connectivity
         try:
-            db = PostgresClient("mira_service")
+            from utils.instance import database_name
+            db = PostgresClient(database_name())
             db.execute_single("SELECT 1")
             components["database"] = {"status": "healthy", "latency_ms": round((time.time() - start_time) * 1000, 1)}
         except (psycopg.OperationalError, psycopg.DatabaseError) as e:

--- a/cns/infrastructure/continuum_repository.py
+++ b/cns/infrastructure/continuum_repository.py
@@ -80,7 +80,8 @@ class ContinuumRepository:
     def _get_client(self, user_id: str) -> PostgresClient:
         """Get or create database client for user."""
         if user_id not in self._db_cache:
-            self._db_cache[user_id] = PostgresClient("mira_service", user_id=user_id)
+            from utils.instance import database_name
+            self._db_cache[user_id] = PostgresClient(database_name(), user_id=user_id)
         return self._db_cache[user_id]
     
     def get_continuum(self, user_id: str) -> Continuum | None:

--- a/cns/services/peanutgallery_service.py
+++ b/cns/services/peanutgallery_service.py
@@ -31,7 +31,9 @@ from utils.user_context import get_current_user_id
 
 logger = logging.getLogger(__name__)
 
-USER_DATA_BASE = Path("data/users")
+from utils.instance import user_data_base
+
+USER_DATA_BASE = user_data_base()
 
 
 class PeanutGalleryService:

--- a/cns/services/portrait_service.py
+++ b/cns/services/portrait_service.py
@@ -128,7 +128,8 @@ def read_portrait(user_id: str) -> str:
     """
     try:
         from clients.postgres_client import PostgresClient
-        db = PostgresClient('mira_service')
+        from utils.instance import database_name
+        db = PostgresClient(database_name())
         row = db.execute_single(
             "SELECT portrait FROM users WHERE id = %s",
             (user_id,)
@@ -192,8 +193,9 @@ def _save_portrait(user_id: str, content: str) -> None:
     """Write portrait to the users table in PostgreSQL."""
     from clients.postgres_client import PostgresClient
     from utils.timezone_utils import utc_now
+    from utils.instance import database_name
 
-    db = PostgresClient('mira_service')
+    db = PostgresClient(database_name())
     db.execute_update(
         "UPDATE users SET portrait = %s, portrait_generated_at = %s WHERE id = %s",
         (content, utc_now(), UUID(user_id)),

--- a/cns/services/subcortical.py
+++ b/cns/services/subcortical.py
@@ -266,7 +266,8 @@ class SubcorticalLayer:
                 logger.debug("No user context, skipping subcortical output persistence")
                 return
 
-            output_dir = Path("data/users") / str(user_id)
+            from utils.instance import user_data_base
+            output_dir = user_data_base() / str(user_id)
             output_dir.mkdir(parents=True, exist_ok=True)
             output_file = output_dir / "subcortical_outputs.jsonl"
 

--- a/config/config.py
+++ b/config/config.py
@@ -6,7 +6,7 @@ Only values that operators change without code changes belong here:
 feature flags, infrastructure coordinates, scheduling cadences, deployment settings.
 """
 
-from typing import List
+from typing import Any, List
 
 from pydantic import BaseModel, Field
 
@@ -55,6 +55,13 @@ class ApiServerConfig(BaseModel):
     log_level: str = Field(default="warning", description="Log level for uvicorn server")
     extended_thinking: bool = Field(default=False, description="Enable extended thinking capability")
     extended_thinking_budget: int = Field(default=1024, description="Token budget for extended thinking (min: 1024)")
+
+    def model_post_init(self, __context: Any) -> None:
+        import os
+        if port_override := os.environ.get("MIRA_PORT"):
+            self.port = int(port_override)
+        if cors_override := os.environ.get("MIRA_CORS_ORIGINS"):
+            self.cors_origins = [o.strip() for o in cors_override.split(",")]
 
 
 class SystemConfig(BaseModel):

--- a/config/config.py
+++ b/config/config.py
@@ -58,9 +58,16 @@ class ApiServerConfig(BaseModel):
 
     def model_post_init(self, __context: Any) -> None:
         import os
-        if port_override := os.environ.get("MIRA_PORT"):
+        port_override = os.environ.get("MIRA_PORT")
+        cors_override = os.environ.get("MIRA_CORS_ORIGINS")
+        if port_override:
             self.port = int(port_override)
-        if cors_override := os.environ.get("MIRA_CORS_ORIGINS"):
+            if not cors_override:
+                self.cors_origins = [
+                    origin.replace(":1993", f":{self.port}")
+                    for origin in self.cors_origins
+                ]
+        if cors_override:
             self.cors_origins = [o.strip() for o in cors_override.split(",")]
 
 

--- a/docs/multi-instance.md
+++ b/docs/multi-instance.md
@@ -1,0 +1,107 @@
+# Running Multiple MIRA Instances
+
+Run independent MIRA instances from a single codebase using the `MIRA_INSTANCE` environment variable.
+
+## Quick Start
+
+```bash
+# Instance 1 (default — your existing setup, no changes needed)
+python main.py
+
+# Instance 2
+MIRA_INSTANCE=kristen MIRA_PORT=1994 python main.py
+```
+
+## What MIRA_INSTANCE Controls
+
+| Resource | Default | `MIRA_INSTANCE=kristen` |
+|----------|---------|------------------------|
+| Database | `mira_service` | `mira_service_kristen` |
+| Vault prefix | `mira/` | `mira-kristen/` |
+| Data directory | `data/users/` | `data-kristen/users/` |
+| Valkey keys | (no prefix) | `kristen:` |
+| Port | 1993 | Set via `MIRA_PORT` |
+
+## Setup Steps
+
+### 1. Create the Database
+
+```bash
+psql -U postgres -h localhost -c "
+  CREATE DATABASE mira_service_kristen OWNER mira_admin;
+"
+psql -U postgres -h localhost -d mira_service_kristen \
+  -f deploy/mira_service_schema.sql
+```
+
+Grant the application roles access:
+```bash
+psql -U postgres -h localhost -d mira_service_kristen -c "
+  GRANT CONNECT ON DATABASE mira_service_kristen TO mira_dbuser;
+  GRANT CONNECT ON DATABASE mira_service_kristen TO mira_admin;
+"
+```
+
+### 2. Create Vault Secrets
+
+```bash
+# Database connection strings (update password as needed)
+vault kv put secret/mira-kristen/database \
+  admin_url="postgresql://mira_admin:<password>@localhost:5432/mira_service_kristen" \
+  service_url="postgresql://mira_dbuser:<password>@localhost:5432/mira_service_kristen"
+
+# API keys — can share with default instance or use separate keys
+vault kv put secret/mira-kristen/api_keys \
+  anthropic_key="$(vault kv get -field=anthropic_key secret/mira/api_keys)" \
+  anthropic_batch_key="$(vault kv get -field=anthropic_batch_key secret/mira/api_keys)" \
+  mira_api="$(uuidgen)"
+
+# Services config
+vault kv put secret/mira-kristen/services \
+  app_url="http://localhost:1994" \
+  valkey_url="valkey://localhost:6379"
+```
+
+### 3. Create Data Directory
+
+```bash
+mkdir -p data-kristen/users
+```
+
+### 4. Start the Instance
+
+```bash
+MIRA_INSTANCE=kristen \
+MIRA_PORT=1994 \
+MIRA_CORS_ORIGINS="http://localhost:1994,http://mira-k:1994" \
+python main.py
+```
+
+### 5. (Optional) Reverse Proxy
+
+Add to your Caddyfile or nginx config to serve at a clean URL:
+
+```
+# Caddyfile
+http://mira-k {
+    reverse_proxy localhost:1994
+}
+```
+
+Then add `http://mira-k` to `MIRA_CORS_ORIGINS`.
+
+## Sharing Resources
+
+All instances on the same host share:
+- PostgreSQL server (different databases)
+- Vault server (different secret paths)
+- Valkey server (different key prefixes)
+- Python venv and codebase
+- Anthropic API key (if configured to share)
+
+Each instance has its own:
+- Conversations and memories
+- User identity and API key
+- Working memory and system prompt personality
+- Scheduled background jobs
+- File uploads and tool state

--- a/main.py
+++ b/main.py
@@ -361,7 +361,8 @@ async def lifespan(app: FastAPI):
 
         def mira_resolve_username(username: str) -> Optional[str]:
             """Resolve username to user_id for Lattice federation."""
-            db = PostgresClient("mira_service")
+            from utils.instance import database_name
+            db = PostgresClient(database_name())
             result = db.execute_single(
                 "SELECT user_id FROM global_usernames WHERE username = %(username)s AND active = true",
                 {"username": username.lower()}

--- a/main.py
+++ b/main.py
@@ -82,9 +82,10 @@ def ensure_single_user(app: FastAPI) -> None:
 
             try:
                 from clients.vault_client import _ensure_vault_client
+                from utils.instance import vault_prefix
                 vault_client = _ensure_vault_client()
                 secret_data = vault_client.client.secrets.kv.v2.read_secret_version(
-                    path='mira/api_keys'
+                    path=f'{vault_prefix()}/api_keys'
                 )
                 api_key = secret_data['data']['data'].get('mira_api')
                 app.state.api_key = api_key
@@ -168,10 +169,11 @@ def ensure_single_user(app: FastAPI) -> None:
 
     try:
         from clients.vault_client import _ensure_vault_client
+        from utils.instance import vault_prefix
         vault_client = _ensure_vault_client()
         # Use patch to add mira_api without overwriting anthropic_key/openaicompat_key
         vault_client.client.secrets.kv.v2.patch(
-            path='mira/api_keys',
+            path=f'{vault_prefix()}/api_keys',
             secret=dict(mira_api=api_key)
         )
     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -197,8 +197,12 @@ async def lifespan(app: FastAPI):
     """Application lifecycle management."""
     
     # Startup
-    logger.info("  Starting MIRA...\n\n\n")
-    logger.info("====================")
+    from utils.instance import INSTANCE_NAME, database_name, vault_prefix, valkey_prefix
+    if INSTANCE_NAME != "default":
+        logger.warning(
+            f"MIRA instance '{INSTANCE_NAME}' — "
+            f"db={database_name()}, vault={vault_prefix()}, valkey_prefix={valkey_prefix()!r}"
+        )
 
     # Ensure single user exists and load credentials
     ensure_single_user(app)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,0 +1,73 @@
+"""Tests for MIRA instance identity derivation."""
+import os
+import pytest
+from unittest.mock import patch
+
+
+class TestInstanceIdentity:
+    """Test instance name derivation from environment."""
+
+    def test_default_instance_name(self):
+        with patch.dict(os.environ, {}, clear=True):
+            from utils.instance import _read_instance_name
+            assert _read_instance_name() == "default"
+
+    def test_custom_instance_name(self):
+        with patch.dict(os.environ, {"MIRA_INSTANCE": "kristen"}):
+            from utils.instance import _read_instance_name
+            assert _read_instance_name() == "kristen"
+
+    def test_instance_name_stripped_and_lowered(self):
+        with patch.dict(os.environ, {"MIRA_INSTANCE": "  Kristen  "}):
+            from utils.instance import _read_instance_name
+            assert _read_instance_name() == "kristen"
+
+
+class TestVaultPrefix:
+    def test_default_vault_prefix(self):
+        from utils.instance import vault_prefix
+        with patch("utils.instance.INSTANCE_NAME", "default"):
+            assert vault_prefix() == "mira"
+
+    def test_custom_vault_prefix(self):
+        from utils.instance import vault_prefix
+        with patch("utils.instance.INSTANCE_NAME", "kristen"):
+            assert vault_prefix() == "mira-kristen"
+
+
+class TestDatabaseName:
+    def test_default_database_name(self):
+        from utils.instance import database_name
+        with patch("utils.instance.INSTANCE_NAME", "default"):
+            assert database_name() == "mira_service"
+
+    def test_custom_database_name(self):
+        from utils.instance import database_name
+        with patch("utils.instance.INSTANCE_NAME", "kristen"):
+            assert database_name() == "mira_service_kristen"
+
+
+class TestDataDir:
+    def test_default_data_dir(self):
+        from utils.instance import user_data_base
+        with patch("utils.instance.INSTANCE_NAME", "default"):
+            from pathlib import Path
+            assert user_data_base() == Path("data/users")
+
+    def test_custom_data_dir(self):
+        from utils.instance import user_data_base
+        with patch("utils.instance.INSTANCE_NAME", "kristen"):
+            from pathlib import Path
+            assert user_data_base() == Path("data-kristen/users")
+
+
+class TestValkeyPrefix:
+    def test_default_valkey_prefix(self):
+        from utils.instance import valkey_prefix
+        with patch("utils.instance.INSTANCE_NAME", "default"):
+            assert valkey_prefix() == ""
+
+    def test_custom_valkey_prefix(self):
+        from utils.instance import valkey_prefix
+        with patch("utils.instance.INSTANCE_NAME", "kristen"):
+            assert valkey_prefix() == "kristen:"

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -22,6 +22,33 @@ class TestInstanceIdentity:
             from utils.instance import _read_instance_name
             assert _read_instance_name() == "kristen"
 
+    def test_empty_instance_name_falls_back_to_default(self):
+        with patch.dict(os.environ, {"MIRA_INSTANCE": ""}):
+            from utils.instance import _read_instance_name
+            assert _read_instance_name() == "default"
+
+    def test_whitespace_only_falls_back_to_default(self):
+        with patch.dict(os.environ, {"MIRA_INSTANCE": "   "}):
+            from utils.instance import _read_instance_name
+            assert _read_instance_name() == "default"
+
+    def test_invalid_characters_rejected(self):
+        with patch.dict(os.environ, {"MIRA_INSTANCE": "../etc"}):
+            from utils.instance import _read_instance_name
+            with pytest.raises(ValueError, match="invalid"):
+                _read_instance_name()
+
+    def test_leading_digit_rejected(self):
+        with patch.dict(os.environ, {"MIRA_INSTANCE": "2fast"}):
+            from utils.instance import _read_instance_name
+            with pytest.raises(ValueError, match="invalid"):
+                _read_instance_name()
+
+    def test_underscores_accepted(self):
+        with patch.dict(os.environ, {"MIRA_INSTANCE": "dev_test"}):
+            from utils.instance import _read_instance_name
+            assert _read_instance_name() == "dev_test"
+
 
 class TestVaultPrefix:
     def test_default_vault_prefix(self):

--- a/tools/implementations/imagegen_tool.py
+++ b/tools/implementations/imagegen_tool.py
@@ -225,7 +225,8 @@ class ImageGenerationTool(Tool):
 
         user_id = str(get_current_user_id())
         file_id = f"imggen_{uuid4().hex[:12]}"
-        file_dir = Path("data/users") / user_id / "artifacts" / file_id
+        from utils.instance import user_data_base
+        file_dir = user_data_base() / user_id / "artifacts" / file_id
         file_dir.mkdir(parents=True, exist_ok=True)
 
         random_stem = uuid4().hex
@@ -254,7 +255,8 @@ class ImageGenerationTool(Tool):
         from utils.user_context import get_current_user_id
 
         user_id = str(get_current_user_id())
-        file_dir = Path("data/users") / user_id / "artifacts" / file_id
+        from utils.instance import user_data_base
+        file_dir = user_data_base() / user_id / "artifacts" / file_id
 
         if not file_dir.is_dir():
             raise ValueError(f"Image not found: {file_id}")

--- a/tools/implementations/pager_tool.py
+++ b/tools/implementations/pager_tool.py
@@ -629,7 +629,8 @@ class PagerTool(Tool):
 
         # Check if user already has a username (MIRA's user registry)
         from clients.postgres_client import PostgresClient
-        postgres_db = PostgresClient("mira_service")
+        from utils.instance import database_name
+        postgres_db = PostgresClient(database_name())
 
         existing = postgres_db.execute_single(
             """
@@ -705,7 +706,8 @@ class PagerTool(Tool):
             ValueError: If recipient cannot be resolved
         """
         from clients.postgres_client import PostgresClient
-        postgres_db = PostgresClient("mira_service")
+        from utils.instance import database_name
+        postgres_db = PostgresClient(database_name())
 
         # Resolve username to user_id via global_usernames
         username_result = postgres_db.execute_single(
@@ -778,7 +780,8 @@ class PagerTool(Tool):
 
         # Get username for this user (from MIRA's user registry)
         from clients.postgres_client import PostgresClient
-        postgres_db = PostgresClient("mira_service")
+        from utils.instance import database_name
+        postgres_db = PostgresClient(database_name())
 
         username_result = postgres_db.execute_single(
             """

--- a/tools/implementations/pager_tool.py
+++ b/tools/implementations/pager_tool.py
@@ -305,8 +305,8 @@ class PagerTool(Tool):
 
         try:
             # Construct user's database path
-            from pathlib import Path
-            user_db_path = Path("data/users") / self.user_id / "userdata.db"
+            from utils.instance import user_data_base
+            user_db_path = user_data_base() / self.user_id / "userdata.db"
 
             if not user_db_path.exists():
                 raise ValueError(f"User database not found for user_id {self.user_id}")

--- a/tools/schema_distribution.py
+++ b/tools/schema_distribution.py
@@ -26,7 +26,8 @@ def initialize_user_database(user_id: str) -> None:
     Raises:
         RuntimeError: If database initialization fails
     """
-    db_path = Path(f"data/users/{user_id}/userdata.db")
+    from utils.instance import user_data_base
+    db_path = user_data_base() / user_id / "userdata.db"
 
     # Ensure user directory exists
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -91,7 +92,8 @@ def apply_schema_to_all_users(schema_name: str) -> Dict[str, List]:
     with open(schema_path, 'r') as f:
         schema_sql = f.read()
 
-    users_dir = Path("data/users")
+    from utils.instance import user_data_base
+    users_dir = user_data_base()
     results = {"success": [], "failed": []}
 
     if not users_dir.exists():
@@ -135,8 +137,9 @@ def apply_all_schemas_to_all_users() -> Dict[str, int]:
     Returns:
         Dict with counts of users updated and failed
     """
+    from utils.instance import user_data_base
     schema_dir = Path("tools/implementations/schemas")
-    users_dir = Path("data/users")
+    users_dir = user_data_base()
 
     if not schema_dir.exists():
         logger.error(f"Schema directory not found: {schema_dir}")

--- a/utils/CLAUDE.md
+++ b/utils/CLAUDE.md
@@ -11,6 +11,7 @@
 
 ## Files
 
+- `instance.py` — MIRA instance identity. Reads `MIRA_INSTANCE` env var once at import. Exports `INSTANCE_NAME` and 4 derivation functions: `vault_prefix()`, `database_name()`, `user_data_base()`, `valkey_prefix()`. All instance-specific resource names flow from this module. Validates input: rejects empty, non-alphanumeric, or digit-leading names with `ValueError`.
 - `user_context.py` — Owns user identity contextvar (`set_current_user_id` / `get_current_user_id`), segment context, `UserPreferences` model + `get_user_preferences()`, `ConversationLLMConfig` / `get_conversation_llms()`, and `InternalLLMConfig` / `get_internal_llm()`.
 - `database_session_manager.py` — Singleton PostgreSQL connection pool (`get_shared_session_manager()`); `LTMemorySession` enforces RLS, `AdminSession` bypasses it.
 - `perf.py` — Performance instrumentation; monkey-patches `execute_*` methods at startup via `install_db_instrumentation()`. Gated by `mira.perf` logger level.

--- a/utils/database_session_manager.py
+++ b/utils/database_session_manager.py
@@ -79,7 +79,8 @@ class LTMemorySessionManager:
         if not user_id:
             raise ValueError("user_id is required for database operations")
 
-        pool = self._get_or_create_pool('mira_service')
+        from utils.instance import database_name
+        pool = self._get_or_create_pool(database_name())
         return LTMemorySession(pool, user_id)
 
     def get_admin_session(self) -> 'AdminSession':
@@ -91,31 +92,33 @@ class LTMemorySessionManager:
         Uses mira_admin role which has BYPASSRLS privilege.
 
         Returns:
-            AdminSession for mira_service database
+            AdminSession for the instance database
         """
-        pool = self._get_or_create_pool('mira_service_admin')
+        from utils.instance import database_name
+        pool = self._get_or_create_pool(f'{database_name()}_admin')
         return AdminSession(pool)
 
-    def _get_or_create_pool(self, database_name: str) -> ConnectionPool:
+    def _get_or_create_pool(self, pool_name: str) -> ConnectionPool:
         """
         Get existing pool or create new one for database.
 
         Args:
-            database_name: Name of database in Vault configuration
-                          'mira_service' = regular user access with RLS
-                          'mira_service_admin' = admin access with BYPASSRLS
+            pool_name: Pool identifier — the instance database name for regular
+                       access, or '{db_name}_admin' for BYPASSRLS access.
 
         Returns:
             Connection pool for the specified database
         """
         with self._lock:
-            if database_name not in self._pools:
+            if pool_name not in self._pools:
                 try:
                     from clients.vault_client import get_database_url
+                    from utils.instance import database_name as instance_db_name
 
                     # Determine if this is an admin pool
-                    is_admin = database_name == 'mira_service_admin'
-                    actual_db_name = 'mira_service'  # Both connect to same database
+                    db_name = instance_db_name()
+                    is_admin = pool_name == f'{db_name}_admin'
+                    actual_db_name = db_name  # Both connect to same database
 
                     conninfo = PostgresClient._parse_database_url(
                         get_database_url(actual_db_name, admin=is_admin)
@@ -133,13 +136,13 @@ class LTMemorySessionManager:
                         kwargs={'options': '-c statement_timeout=300000'}  # 5 minute statement timeout
                     )
 
-                    self._pools[database_name] = pool
+                    self._pools[pool_name] = pool
 
                 except Exception as e:
-                    logger.error(f"Failed to create connection pool for {database_name}: {e}")
+                    logger.error(f"Failed to create connection pool for {pool_name}: {e}")
                     raise ValueError(f"Database pool creation failed: {str(e)}")
 
-            return self._pools[database_name]
+            return self._pools[pool_name]
     
     def _cleanup_all_pools(self):
         """Clean up all connection pools on shutdown."""

--- a/utils/domaindoc_shares.py
+++ b/utils/domaindoc_shares.py
@@ -44,7 +44,8 @@ class AcceptedShare:
 def _get_pg(user_id: UUID):
     """Get a PostgresClient with user_id set for RLS enforcement."""
     from clients.postgres_client import PostgresClient
-    return PostgresClient("mira_service", user_id=str(user_id))
+    from utils.instance import database_name
+    return PostgresClient(database_name(), user_id=str(user_id))
 
 
 def is_shared_label(label: str) -> bool:

--- a/utils/instance.py
+++ b/utils/instance.py
@@ -1,0 +1,42 @@
+"""
+MIRA instance identity.
+
+Reads MIRA_INSTANCE from environment once at import time.
+All instance-specific names (database, Vault paths, data dir, Valkey prefix)
+derive from this single value. When unset or "default", all names match
+the original hardcoded values for backwards compatibility.
+"""
+import os
+from pathlib import Path
+
+
+def _read_instance_name() -> str:
+    raw = os.environ.get("MIRA_INSTANCE", "default")
+    return raw.strip().lower()
+
+
+INSTANCE_NAME: str = _read_instance_name()
+
+
+def vault_prefix() -> str:
+    if INSTANCE_NAME == "default":
+        return "mira"
+    return f"mira-{INSTANCE_NAME}"
+
+
+def database_name() -> str:
+    if INSTANCE_NAME == "default":
+        return "mira_service"
+    return f"mira_service_{INSTANCE_NAME}"
+
+
+def user_data_base() -> Path:
+    if INSTANCE_NAME == "default":
+        return Path("data/users")
+    return Path(f"data-{INSTANCE_NAME}/users")
+
+
+def valkey_prefix() -> str:
+    if INSTANCE_NAME == "default":
+        return ""
+    return f"{INSTANCE_NAME}:"

--- a/utils/instance.py
+++ b/utils/instance.py
@@ -7,12 +7,20 @@ derive from this single value. When unset or "default", all names match
 the original hardcoded values for backwards compatibility.
 """
 import os
+import re
 from pathlib import Path
 
 
 def _read_instance_name() -> str:
-    raw = os.environ.get("MIRA_INSTANCE", "default")
-    return raw.strip().lower()
+    raw = os.environ.get("MIRA_INSTANCE", "default").strip().lower()
+    if not raw:
+        return "default"
+    if raw != "default" and not re.fullmatch(r'[a-z][a-z0-9_]*', raw):
+        raise ValueError(
+            f"MIRA_INSTANCE={raw!r} is invalid. "
+            "Must start with a letter and contain only lowercase letters, digits, and underscores."
+        )
+    return raw
 
 
 INSTANCE_NAME: str = _read_instance_name()

--- a/utils/user_context.py
+++ b/utils/user_context.py
@@ -203,7 +203,8 @@ def get_conversation_llms() -> dict[str, ConversationLLMConfig]:
         return _conversation_llm_cache
 
     from clients.postgres_client import PostgresClient
-    db = PostgresClient('mira_service')
+    from utils.instance import database_name
+    db = PostgresClient(database_name())
 
     results = db.execute_query(
         "SELECT name, model, thinking_budget, description, display_order, provider, endpoint_url, api_key_name, hidden FROM conversation_llm ORDER BY display_order"
@@ -262,7 +263,8 @@ def load_internal_llm_configs() -> None:
     """Load internal LLM configs at startup. Call during app boot."""
     global _internal_llm_cache
     from clients.postgres_client import PostgresClient
-    db = PostgresClient('mira_service')
+    from utils.instance import database_name
+    db = PostgresClient(database_name())
     results = db.execute_query(
         "SELECT name, tier, model, endpoint_url, api_key_name, description, "
         "max_tokens, effort FROM internal_llm"
@@ -325,7 +327,8 @@ def _resolve_user_internal_tier() -> str:
     user_id = get_current_user_id()
 
     from clients.postgres_client import PostgresClient
-    db = PostgresClient("mira_service", admin=True)
+    from utils.instance import database_name
+    db = PostgresClient(database_name(), admin=True)
     result = db.execute_single(
         "SELECT stripe_payment_method_id FROM users WHERE id = %s",
         (user_id,),
@@ -379,7 +382,8 @@ def get_user_preferences() -> UserPreferences:
         return UserPreferences(**data)
 
     # Cache miss - fetch from database
-    db = PostgresClient('mira_service')
+    from utils.instance import database_name
+    db = PostgresClient(database_name())
     result = db.execute_single(
         """SELECT first_name, last_name, timezone, temperature_unit, memory_manipulation_enabled, conversation_llm, created_at
            FROM users WHERE id = %s""",
@@ -421,7 +425,8 @@ def update_user_preference(field: str, value: Any) -> UserPreferences:
     from clients.postgres_client import PostgresClient
     from clients.valkey_client import get_valkey_client
 
-    db = PostgresClient('mira_service')
+    from utils.instance import database_name
+    db = PostgresClient(database_name())
 
     db.execute_update(
         f"UPDATE users SET {field} = %s WHERE id = %s",

--- a/utils/userdata_manager.py
+++ b/utils/userdata_manager.py
@@ -82,7 +82,8 @@ class UserDataManager:
     
     @property
     def base_dir(self) -> Path:
-        user_dir = Path("data/users") / str(self.user_id)
+        from utils.instance import user_data_base
+        user_dir = user_data_base() / str(self.user_id)
         user_dir.mkdir(parents=True, exist_ok=True)
         return user_dir
     


### PR DESCRIPTION
## Summary

Run independent MIRA instances from a single codebase using the `MIRA_INSTANCE` environment variable. All instance-specific resource names (database, Vault paths, data directory, Valkey key prefix) derive from this single value. When unset, behavior is identical to the current hardcoded values — zero impact on existing deployments.

- **New module** `utils/instance.py` — reads `MIRA_INSTANCE` once at import, exports 4 derivation functions
- **All hardcoded references replaced** — `PostgresClient("mira_service")` → `PostgresClient(database_name())`, `Path("data/users")` → `user_data_base()`, etc. across ~20 files
- **Valkey key isolation** — all key-accepting methods apply instance prefix; scan/flush scoped to instance keys only
- **Input validation** — rejects empty, path-traversal, and non-alphanumeric instance names at startup
- **CORS auto-update** — `MIRA_PORT` without `MIRA_CORS_ORIGINS` auto-derives correct localhost origins
- **16 unit tests** covering all derivation functions, input normalization, and validation edge cases
- **Setup guide** at `docs/multi-instance.md`

## What's shared between instances

- PostgreSQL server (different databases)
- Vault server (different secret paths)  
- Valkey server (different key prefixes)
- Python venv and codebase
- Anthropic API key (if configured)

## What's isolated

- Conversations and memories
- User identity and API key
- Working memory and system prompt
- Scheduled background jobs
- File uploads and tool state

## Test plan

- [x] All 16 unit tests pass (`pytest tests/test_instance.py`)
- [x] Default instance (`MIRA_INSTANCE` unset) produces identical resource names to hardcoded originals
- [x] Custom instance derives correct names (`mira_service_kristen`, `mira-kristen/`, `kristen:`)
- [x] Empty `MIRA_INSTANCE=""` falls back to default (not broken names)
- [x] Invalid names (`../etc`, `2fast`) rejected with `ValueError` at startup
- [x] `grep -rn '"mira_service"'` returns only `utils/instance.py` default
- [x] Valkey binary operations use prefix-aware methods
- [x] `MIRA_PORT=1994` auto-updates CORS origins when `MIRA_CORS_ORIGINS` not set

🤖 Generated with [Claude Code](https://claude.ai/code)