### PR TITLE
fix: filter tool messages from conversation history

### DIFF
--- a/cns/infrastructure/continuum_repository.py
+++ b/cns/infrastructure/continuum_repository.py
@@ -687,9 +687,11 @@ class ContinuumRepository:
             # Include all messages, no additional filter
             pass
         else:
-            # Default to regular messages (exclude system notifications)
+            # Default to regular messages (exclude system notifications and tool interactions)
             where_conditions.append("(metadata->>'system_notification' IS NULL OR metadata->>'system_notification' != 'true')")
-        
+            where_conditions.append("role != 'tool'")
+            where_conditions.append("(metadata->>'has_tool_calls' IS NULL OR metadata->>'has_tool_calls' != 'true')")
+
         if start_date:
             where_conditions.append("created_at >= %s")
             params.append(start_date)
@@ -755,8 +757,10 @@ class ContinuumRepository:
             # Include all messages, no filter
             pass
         else:
-            # Default to regular messages (exclude system notifications)
-            type_filter = "AND (metadata->>'system_notification' IS NULL OR metadata->>'system_notification' != 'true')"
+            # Default to regular messages (exclude system notifications and tool interactions)
+            type_filter = ("AND (metadata->>'system_notification' IS NULL OR metadata->>'system_notification' != 'true') "
+                          "AND role != 'tool' "
+                          "AND (metadata->>'has_tool_calls' IS NULL OR metadata->>'has_tool_calls' != 'true')")
         
         # Use PostgreSQL full-text search
         query = f"""


### PR DESCRIPTION
## Summary
- Tool interactions (`role='tool'` results and `has_tool_calls` assistant messages) are persisted for segment reconstruction but were returned unfiltered by the history API
- Clients render these as raw JSON chat bubbles on page refresh — column schemas, error dicts, query results all appear as regular "MIRA" messages
- Adds SQL filters to `get_history()` and `search_continuums()` to exclude tool messages from the default `regular` message type; `all` still returns everything for debugging

## Test plan
- [ ] Send a message that triggers tool use, refresh the page — tool results should no longer appear as chat messages
- [ ] Verify `message_type=all` still returns tool messages (for debugging)
- [ ] Verify search results also exclude tool messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)